### PR TITLE
Implement SDL2 CRT terminal emulator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.16)
+project(CoolRetroTerminalClone VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(SDL2 REQUIRED sdl2)
+pkg_check_modules(SDL2TTF REQUIRED SDL2_ttf)
+
+add_executable(cool_retro_terminal
+    src/main.cpp
+    src/terminal.cpp
+    src/ansi_parser.cpp
+    src/crt_effect.cpp
+    src/font_atlas.cpp
+)
+
+target_include_directories(cool_retro_terminal
+    PRIVATE
+        include
+        ${SDL2_INCLUDE_DIRS}
+        ${SDL2TTF_INCLUDE_DIRS}
+)
+
+target_compile_options(cool_retro_terminal PRIVATE ${SDL2_CFLAGS_OTHER} ${SDL2TTF_CFLAGS_OTHER})
+
+target_link_libraries(cool_retro_terminal
+    PRIVATE
+        ${SDL2_LIBRARIES}
+        ${SDL2TTF_LIBRARIES}
+)
+
+if(MSVC)
+    target_compile_options(cool_retro_terminal PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(cool_retro_terminal PRIVATE -Wall -Wextra -Wpedantic)
+endif()

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,66 @@
-# Simple Makefile wrapper around the CMake build for convenience
+# Build the Cool Retro Terminal clone without requiring CMake
 
+CXX ?= g++
+PKG_CONFIG ?= pkg-config
 BUILD_DIR ?= build
-CONFIGURE_FLAGS ?=
+OBJ_DIR := $(BUILD_DIR)/obj
+TARGET := $(BUILD_DIR)/cool_retro_terminal
 
-.PHONY: all configure build clean run
+SRCS := \
+    src/main.cpp \
+    src/terminal.cpp \
+    src/ansi_parser.cpp \
+    src/crt_effect.cpp \
+    src/font_atlas.cpp
 
-all: build
+OBJS := $(SRCS:src/%.cpp=$(OBJ_DIR)/%.o)
 
-configure:
-	cmake -S . -B $(BUILD_DIR) $(CONFIGURE_FLAGS)
+# Validate toolchain availability up-front to fail fast with clear guidance
+ifeq ($(shell command -v $(PKG_CONFIG) >/dev/null 2>&1 && echo yes),yes)
+else
+$(error pkg-config not found. Please install pkg-config to build this project.)
+endif
 
-build: configure
-	cmake --build $(BUILD_DIR)
+SDL2_CFLAGS := $(shell $(PKG_CONFIG) --cflags sdl2 2>/dev/null)
+SDL2_LIBS := $(shell $(PKG_CONFIG) --libs sdl2 2>/dev/null)
+SDL2TTF_CFLAGS := $(shell $(PKG_CONFIG) --cflags SDL2_ttf 2>/dev/null)
+SDL2TTF_LIBS := $(shell $(PKG_CONFIG) --libs SDL2_ttf 2>/dev/null)
+
+ifeq ($(SDL2_CFLAGS),)
+$(error SDL2 development files not found. Install libsdl2-dev or the equivalent package.)
+endif
+ifeq ($(SDL2TTF_CFLAGS),)
+$(error SDL2_ttf development files not found. Install libsdl2-ttf-dev or the equivalent package.)
+endif
+
+CPPFLAGS ?=
+CPPFLAGS += -Iinclude $(SDL2_CFLAGS) $(SDL2TTF_CFLAGS)
+CXXFLAGS ?=
+CXXFLAGS += -std=c++20 -Wall -Wextra -Wpedantic -MMD -MP
+LDFLAGS ?=
+LDLIBS ?=
+LDLIBS += $(SDL2_LIBS) $(SDL2TTF_LIBS) -lutil
+
+.PHONY: all clean run
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS) | $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ $(LDLIBS) -o $@
+
+$(OBJ_DIR)/%.o: src/%.cpp | $(OBJ_DIR)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+
+$(BUILD_DIR):
+	mkdir -p $@
+
+$(OBJ_DIR): | $(BUILD_DIR)
+	mkdir -p $@
 
 clean:
 	rm -rf $(BUILD_DIR)
 
-run: build
-	$(BUILD_DIR)/cool_retro_terminal
+run: $(TARGET)
+	$(TARGET)
+
+-include $(OBJS:.o=.d)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Simple Makefile wrapper around the CMake build for convenience
+
+BUILD_DIR ?= build
+CONFIGURE_FLAGS ?=
+
+.PHONY: all configure build clean run
+
+all: build
+
+configure:
+	cmake -S . -B $(BUILD_DIR) $(CONFIGURE_FLAGS)
+
+build: configure
+	cmake --build $(BUILD_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+run: build
+	$(BUILD_DIR)/cool_retro_terminal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# VOS
-SDL based terminal that has CRT emulation.
+# Cool Retro Terminal Clone
+
+This project is a fully featured SDL2-based Linux terminal emulator with CRT-style rendering. It provides a nostalgic aesthetic inspired by vintage monitors while remaining usable for everyday shell work.
+
+## Features
+
+- SDL2 renderer with animated CRT effects including scanlines, vignette, and screen noise
+- Truecolor terminal emulation with ANSI/VT escape sequence support, including SGR color modes and cursor control
+- PTY-backed shell session that respects the current user's login shell and window resizing
+- Dynamic font atlas built on top of SDL_ttf with bold, italic, and underline rendering
+- Configurable monospace font via the `CRT_FONT_PATH` environment variable
+- Default window size of 1920×1080 with resize handling and DPI awareness
+
+## Building
+
+### Prerequisites
+
+- CMake 3.16 or newer
+- A C++20 compiler (GCC, Clang, or MSVC)
+- SDL2 development libraries
+- SDL2_ttf development libraries
+
+On Debian/Ubuntu you can install dependencies via:
+
+```bash
+sudo apt-get install build-essential cmake libsdl2-dev libsdl2-ttf-dev
+```
+
+### Configure and Build
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+The resulting executable will be located at `build/cool_retro_terminal`.
+
+## Running
+
+From the build directory:
+
+```bash
+./cool_retro_terminal
+```
+
+The emulator will spawn your login shell inside a pseudo terminal. Keyboard input (including control sequences and arrow keys) is forwarded to the shell. Text is rendered using the first available monospace font from a set of common candidates. To force a specific font, set `CRT_FONT_PATH` to the path of a TTF font file before launching the application.
+
+## License
+
+This project is provided without an explicit license. Contact the authors for licensing information if you plan to redistribute or modify the software.
+

--- a/README.md
+++ b/README.md
@@ -15,32 +15,31 @@ This project is a fully featured SDL2-based Linux terminal emulator with CRT-sty
 
 ### Prerequisites
 
-- CMake 3.16 or newer
-- A C++20 compiler (GCC, Clang, or MSVC)
+- A C++20 compiler (GCC or Clang recommended)
+- `pkg-config`
 - SDL2 development libraries
 - SDL2_ttf development libraries
 
 On Debian/Ubuntu you can install dependencies via:
 
 ```bash
-sudo apt-get install build-essential cmake libsdl2-dev libsdl2-ttf-dev
+sudo apt-get install build-essential pkg-config libsdl2-dev libsdl2-ttf-dev
 ```
 
-### Configure and Build
+### Build
 
 ```bash
-cmake -S . -B build
-cmake --build build
+make
 ```
 
 The resulting executable will be located at `build/cool_retro_terminal`.
 
 ## Running
 
-From the build directory:
+From the project root:
 
 ```bash
-./cool_retro_terminal
+make run
 ```
 
 The emulator will spawn your login shell inside a pseudo terminal. Keyboard input (including control sequences and arrow keys) is forwarded to the shell. Text is rendered using the first available monospace font from a set of common candidates. To force a specific font, set `CRT_FONT_PATH` to the path of a TTF font file before launching the application.

--- a/include/AnsiParser.h
+++ b/include/AnsiParser.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+class TerminalScreen;
+
+class AnsiParser {
+public:
+    explicit AnsiParser(TerminalScreen& screen);
+    void process(std::string_view data);
+    void reset();
+
+private:
+    void handleControl(uint8_t byte);
+    void dispatchCsi(char finalByte);
+    void executeCsiCommand(char finalByte, const std::vector<int>& parameters, bool privateMode);
+    void executeOscCommand(const std::string& payload);
+    void applySgr(const std::vector<int>& parameters);
+
+    TerminalScreen& m_screen;
+
+    enum class State {
+        Ground,
+        Escape,
+        CsiEntry,
+        CsiParam,
+        OscString,
+        SosPmApcString
+    };
+
+    State m_state{State::Ground};
+    std::vector<int> m_parameters;
+    bool m_privateMode{false};
+    std::string m_intermediate;
+    std::string m_oscBuffer;
+
+    class Utf8Decoder {
+    public:
+        void push(uint8_t byte, const std::function<void(char32_t)>& emit);
+        void reset();
+
+    private:
+        uint32_t m_codepoint{0};
+        int m_expected{0};
+    } m_decoder;
+};
+

--- a/include/CRTEffect.h
+++ b/include/CRTEffect.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <SDL2/SDL.h>
+
+#include <random>
+
+class CRTEffect {
+public:
+    CRTEffect();
+    ~CRTEffect();
+
+    CRTEffect(const CRTEffect&) = delete;
+    CRTEffect& operator=(const CRTEffect&) = delete;
+
+    void ensureResources(SDL_Renderer* renderer, int width, int height);
+    void apply(SDL_Renderer* renderer, SDL_Texture* source);
+
+private:
+    void updateNoise(int width, int height);
+    void drawVignette(SDL_Renderer* renderer, int width, int height);
+    void drawScanlines(SDL_Renderer* renderer, int width, int height);
+
+    SDL_Texture* m_noiseTexture{nullptr};
+    SDL_Texture* m_vignetteTexture{nullptr};
+    std::mt19937 m_rng;
+};
+

--- a/include/FontAtlas.h
+++ b/include/FontAtlas.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <tuple>
+
+struct GlyphTexture {
+    SDL_Texture* texture{nullptr};
+    int width{0};
+    int height{0};
+    int advance{0};
+    int bearingX{0};
+    int bearingY{0};
+};
+
+class FontAtlas {
+public:
+    enum Style : uint8_t {
+        Regular = 0,
+        Bold = 1 << 0,
+        Italic = 1 << 1
+    };
+
+    FontAtlas(SDL_Renderer* renderer, int pixelSize);
+    ~FontAtlas();
+
+    FontAtlas(const FontAtlas&) = delete;
+    FontAtlas& operator=(const FontAtlas&) = delete;
+
+    int cellWidth() const { return m_cellWidth; }
+    int cellHeight() const { return m_cellHeight; }
+    int ascent() const { return m_ascent; }
+    int descent() const { return m_descent; }
+
+    const GlyphTexture& glyph(char32_t codepoint, uint8_t style);
+
+private:
+    std::string resolveFontPath() const;
+    TTF_Font* loadFont(uint8_t styleFlags);
+    SDL_Texture* createGlyphTexture(TTF_Font* font, char32_t codepoint, GlyphTexture& glyphInfo);
+
+    SDL_Renderer* m_renderer{nullptr};
+    std::map<uint8_t, TTF_Font*> m_fonts;
+    std::map<std::tuple<char32_t, uint8_t>, GlyphTexture> m_glyphCache;
+    int m_cellWidth{0};
+    int m_cellHeight{0};
+    int m_ascent{0};
+    int m_descent{0};
+    int m_pixelSize{0};
+    std::string m_fontPath;
+};
+

--- a/include/Terminal.h
+++ b/include/Terminal.h
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <SDL2/SDL.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "AnsiParser.h"
+#include "CRTEffect.h"
+#include "FontAtlas.h"
+
+struct TerminalAttributes {
+    SDL_Color foreground{0x80, 0xff, 0x80, 0xff};
+    SDL_Color background{0x02, 0x08, 0x02, 0xff};
+    bool bold{false};
+    bool italic{false};
+    bool underline{false};
+    bool inverse{false};
+};
+
+struct TerminalCell {
+    char32_t codepoint{U' '};
+    SDL_Color foreground{0x80, 0xff, 0x80, 0xff};
+    SDL_Color background{0x02, 0x08, 0x02, 0xff};
+    bool bold{false};
+    bool italic{false};
+    bool underline{false};
+};
+
+class TerminalScreen {
+public:
+    virtual ~TerminalScreen() = default;
+
+    virtual void putChar(char32_t codepoint) = 0;
+    virtual void carriageReturn() = 0;
+    virtual void lineFeed(bool newLine) = 0;
+    virtual void backspace() = 0;
+    virtual void tab() = 0;
+
+    virtual void cursorUp(int amount) = 0;
+    virtual void cursorDown(int amount) = 0;
+    virtual void cursorForward(int amount) = 0;
+    virtual void cursorBackward(int amount) = 0;
+    virtual void cursorNextLine(int amount) = 0;
+    virtual void cursorPrevLine(int amount) = 0;
+    virtual void setCursorColumn(int column) = 0;
+    virtual void setCursorPosition(int row, int column) = 0;
+
+    virtual void eraseInDisplay(int mode) = 0;
+    virtual void eraseInLine(int mode) = 0;
+    virtual void insertLines(int amount) = 0;
+    virtual void deleteLines(int amount) = 0;
+    virtual void scrollUp(int amount) = 0;
+    virtual void scrollDown(int amount) = 0;
+
+    virtual void setAttributes(const TerminalAttributes& attributes) = 0;
+    virtual TerminalAttributes& attributes() = 0;
+    virtual const TerminalAttributes& defaultAttributes() const = 0;
+    virtual void reset() = 0;
+
+    virtual void saveCursor() = 0;
+    virtual void restoreCursor() = 0;
+    virtual void setCursorVisible(bool visible) = 0;
+
+    virtual int columns() const = 0;
+    virtual int rows() const = 0;
+};
+
+class Terminal : public TerminalScreen {
+public:
+    Terminal(SDL_Renderer* renderer, int width, int height);
+    ~Terminal() override;
+
+    Terminal(const Terminal&) = delete;
+    Terminal& operator=(const Terminal&) = delete;
+
+    void update();
+    void render();
+
+    void handleWindowSize(int width, int height);
+
+    void handleTextInput(const char* text);
+    void handleKeyPress(const SDL_Keysym& keysym, bool repeat);
+
+    bool isChildAlive() const;
+
+    // TerminalScreen implementation
+    void putChar(char32_t codepoint) override;
+    void carriageReturn() override;
+    void lineFeed(bool newLine) override;
+    void backspace() override;
+    void tab() override;
+
+    void cursorUp(int amount) override;
+    void cursorDown(int amount) override;
+    void cursorForward(int amount) override;
+    void cursorBackward(int amount) override;
+    void cursorNextLine(int amount) override;
+    void cursorPrevLine(int amount) override;
+    void setCursorColumn(int column) override;
+    void setCursorPosition(int row, int column) override;
+
+    void eraseInDisplay(int mode) override;
+    void eraseInLine(int mode) override;
+    void insertLines(int amount) override;
+    void deleteLines(int amount) override;
+    void scrollUp(int amount) override;
+    void scrollDown(int amount) override;
+
+    void setAttributes(const TerminalAttributes& attributes) override;
+    TerminalAttributes& attributes() override;
+    const TerminalAttributes& defaultAttributes() const override;
+    void reset() override;
+
+    void saveCursor() override;
+    void restoreCursor() override;
+    void setCursorVisible(bool visible) override;
+
+    int columns() const override { return m_columns; }
+    int rows() const override { return m_rows; }
+
+private:
+    void initializePty();
+    void shutdownPty();
+    void allocateGrid(int width, int height);
+    void applyWinsize();
+    void writeToPty(std::string_view text);
+    void flushPendingInput();
+    void updateCursorBlink();
+    void drawCells();
+    void drawCell(int row, int column, const TerminalCell& cell);
+    void drawCursor();
+
+    struct CursorState {
+        int row{0};
+        int column{0};
+    };
+
+    SDL_Renderer* m_renderer{nullptr};
+    SDL_Texture* m_renderTarget{nullptr};
+    FontAtlas m_fontAtlas;
+    CRTEffect m_crtEffect;
+    AnsiParser m_parser;
+
+    int m_columns{0};
+    int m_rows{0};
+    std::vector<TerminalCell> m_cells;
+
+    CursorState m_cursor{};
+    CursorState m_savedCursor{};
+    TerminalAttributes m_currentAttributes{};
+    TerminalAttributes m_savedAttributes{};
+    TerminalAttributes m_defaultAttributes{};
+    bool m_cursorVisible{true};
+    bool m_cursorBlinkState{true};
+    uint32_t m_lastBlinkTicks{0};
+
+    int m_width{0};
+    int m_height{0};
+
+    int m_masterFd{-1};
+    pid_t m_childPid{-1};
+
+    std::string m_pendingInput;
+    bool m_needsFullRedraw{true};
+};
+

--- a/src/ansi_parser.cpp
+++ b/src/ansi_parser.cpp
@@ -1,0 +1,392 @@
+#include "AnsiParser.h"
+
+#include "Terminal.h"
+
+#include <SDL2/SDL.h>
+
+#include <algorithm>
+#include <charconv>
+#include <cctype>
+#include <stdexcept>
+
+namespace {
+constexpr int kDefaultParamValue = 1;
+}
+
+AnsiParser::AnsiParser(TerminalScreen& screen)
+    : m_screen(screen) {}
+
+void AnsiParser::process(std::string_view data) {
+    for (uint8_t byte : data) {
+        switch (m_state) {
+        case State::Ground:
+            if (byte == 0x1b) {
+                m_state = State::Escape;
+                m_parameters.clear();
+                m_intermediate.clear();
+                m_privateMode = false;
+            } else if (byte < 0x20) {
+                handleControl(byte);
+            } else {
+                m_decoder.push(byte, [this](char32_t cp) { m_screen.putChar(cp); });
+            }
+            break;
+        case State::Escape:
+            if (byte == '[') {
+                m_state = State::CsiEntry;
+                m_parameters.clear();
+                m_intermediate.clear();
+                m_privateMode = false;
+            } else if (byte == ']') {
+                m_state = State::OscString;
+                m_oscBuffer.clear();
+            } else if (byte == '7') {
+                m_screen.saveCursor();
+                m_state = State::Ground;
+            } else if (byte == '8') {
+                m_screen.restoreCursor();
+                m_state = State::Ground;
+            } else if (byte == 'c') {
+                m_screen.reset();
+                m_state = State::Ground;
+            } else if (byte >= 0x20 && byte <= 0x2f) {
+                m_intermediate.push_back(static_cast<char>(byte));
+            } else if (byte >= 0x30 && byte <= 0x7e) {
+                // Unsupported escape sequences
+                m_state = State::Ground;
+            }
+            break;
+        case State::CsiEntry:
+            if (byte == '?') {
+                m_privateMode = true;
+            } else if (byte >= '0' && byte <= '9') {
+                m_parameters.emplace_back(byte - '0');
+                m_state = State::CsiParam;
+            } else if (byte == ';') {
+                m_parameters.emplace_back(0);
+                m_state = State::CsiParam;
+            } else if (byte >= 0x40 && byte <= 0x7e) {
+                dispatchCsi(static_cast<char>(byte));
+                m_state = State::Ground;
+            }
+            break;
+        case State::CsiParam:
+            if (byte >= '0' && byte <= '9') {
+                if (m_parameters.empty()) {
+                    m_parameters.emplace_back(0);
+                }
+                m_parameters.back() = m_parameters.back() * 10 + (byte - '0');
+            } else if (byte == ';') {
+                m_parameters.emplace_back(0);
+            } else if (byte >= 0x40 && byte <= 0x7e) {
+                dispatchCsi(static_cast<char>(byte));
+                m_state = State::Ground;
+            }
+            break;
+        case State::OscString:
+            if (byte == 0x07) {
+                executeOscCommand(m_oscBuffer);
+                m_state = State::Ground;
+            } else if (byte == 0x1b) {
+                m_state = State::SosPmApcString;
+            } else {
+                m_oscBuffer.push_back(static_cast<char>(byte));
+            }
+            break;
+        case State::SosPmApcString:
+            if (byte == '\\') {
+                executeOscCommand(m_oscBuffer);
+                m_state = State::Ground;
+            }
+            break;
+        }
+    }
+}
+
+void AnsiParser::reset() {
+    m_state = State::Ground;
+    m_parameters.clear();
+    m_intermediate.clear();
+    m_privateMode = false;
+    m_oscBuffer.clear();
+    m_decoder.reset();
+}
+
+void AnsiParser::handleControl(uint8_t byte) {
+    switch (byte) {
+    case 0x07:
+        m_screen.setCursorVisible(true);
+        break;
+    case 0x08:
+        m_screen.backspace();
+        break;
+    case 0x09:
+        m_screen.tab();
+        break;
+    case 0x0a:
+        m_screen.lineFeed(true);
+        break;
+    case 0x0d:
+        m_screen.carriageReturn();
+        break;
+    default:
+        break;
+    }
+}
+
+void AnsiParser::dispatchCsi(char finalByte) {
+    executeCsiCommand(finalByte, m_parameters, m_privateMode);
+    m_parameters.clear();
+    m_privateMode = false;
+}
+
+void AnsiParser::executeCsiCommand(char finalByte, const std::vector<int>& parameters, bool privateMode) {
+    auto param = [&parameters](size_t index, int defaultValue) {
+        if (index < parameters.size() && parameters[index] != 0) {
+            return parameters[index];
+        }
+        return defaultValue;
+    };
+
+    switch (finalByte) {
+    case 'A':
+        m_screen.cursorUp(param(0, kDefaultParamValue));
+        break;
+    case 'B':
+        m_screen.cursorDown(param(0, kDefaultParamValue));
+        break;
+    case 'C':
+        m_screen.cursorForward(param(0, kDefaultParamValue));
+        break;
+    case 'D':
+        m_screen.cursorBackward(param(0, kDefaultParamValue));
+        break;
+    case 'E':
+        m_screen.cursorNextLine(param(0, kDefaultParamValue));
+        break;
+    case 'F':
+        m_screen.cursorPrevLine(param(0, kDefaultParamValue));
+        break;
+    case 'G':
+        m_screen.setCursorColumn(std::max(1, param(0, 1)) - 1);
+        break;
+    case 'H':
+    case 'f':
+        m_screen.setCursorPosition(std::max(1, param(0, 1)) - 1, std::max(1, param(1, 1)) - 1);
+        break;
+    case 'J':
+        m_screen.eraseInDisplay(parameters.empty() ? 0 : parameters[0]);
+        break;
+    case 'K':
+        m_screen.eraseInLine(parameters.empty() ? 0 : parameters[0]);
+        break;
+    case 'L':
+        m_screen.insertLines(param(0, 1));
+        break;
+    case 'M':
+        m_screen.deleteLines(param(0, 1));
+        break;
+    case 'S':
+        m_screen.scrollUp(param(0, 1));
+        break;
+    case 'T':
+        m_screen.scrollDown(param(0, 1));
+        break;
+    case 'm':
+        applySgr(parameters);
+        break;
+    case 'h':
+    case 'l':
+        if (privateMode) {
+            if (!parameters.empty() && parameters[0] == 25) {
+                m_screen.setCursorVisible(finalByte == 'h');
+            }
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+void AnsiParser::executeOscCommand(const std::string& payload) {
+    if (payload.empty()) {
+        return;
+    }
+    // OSC commands are currently ignored but parsed to keep state consistent.
+    (void)payload;
+}
+
+void AnsiParser::applySgr(const std::vector<int>& parameters) {
+    auto attrs = m_screen.attributes();
+
+    auto applyColor = [&attrs](int param, bool foreground) {
+        auto setRgb = [&attrs, foreground](uint8_t r, uint8_t g, uint8_t b) {
+            SDL_Color color{r, g, b, 0xff};
+            if (foreground) {
+                attrs.foreground = color;
+            } else {
+                attrs.background = color;
+            }
+        };
+
+        const SDL_Color palette[16] = {
+            {0x00, 0x00, 0x00, 0xff}, {0xaa, 0x00, 0x00, 0xff}, {0x00, 0xaa, 0x00, 0xff}, {0xaa, 0x55, 0x00, 0xff},
+            {0x00, 0x00, 0xaa, 0xff}, {0xaa, 0x00, 0xaa, 0xff}, {0x00, 0xaa, 0xaa, 0xff}, {0xaa, 0xaa, 0xaa, 0xff},
+            {0x55, 0x55, 0x55, 0xff}, {0xff, 0x55, 0x55, 0xff}, {0x55, 0xff, 0x55, 0xff}, {0xff, 0xff, 0x55, 0xff},
+            {0x55, 0x55, 0xff, 0xff}, {0xff, 0x55, 0xff, 0xff}, {0x55, 0xff, 0xff, 0xff}, {0xff, 0xff, 0xff, 0xff},
+        };
+
+        if (param >= 30 && param <= 37) {
+            setRgb(palette[param - 30].r, palette[param - 30].g, palette[param - 30].b);
+        } else if (param >= 40 && param <= 47) {
+            setRgb(palette[param - 40].r, palette[param - 40].g, palette[param - 40].b);
+        } else if (param >= 90 && param <= 97) {
+            setRgb(palette[param - 90 + 8].r, palette[param - 90 + 8].g, palette[param - 90 + 8].b);
+        } else if (param >= 100 && param <= 107) {
+            setRgb(palette[param - 100 + 8].r, palette[param - 100 + 8].g, palette[param - 100 + 8].b);
+        }
+    };
+
+    if (parameters.empty()) {
+        m_screen.setAttributes(m_screen.defaultAttributes());
+        return;
+    }
+
+    for (size_t i = 0; i < parameters.size(); ++i) {
+        int param = parameters[i];
+        switch (param) {
+        case 0:
+            attrs = m_screen.defaultAttributes();
+            break;
+        case 1:
+            attrs.bold = true;
+            break;
+        case 3:
+            attrs.italic = true;
+            break;
+        case 4:
+            attrs.underline = true;
+            break;
+        case 7:
+            attrs.inverse = true;
+            break;
+        case 22:
+            attrs.bold = false;
+            break;
+        case 23:
+            attrs.italic = false;
+            break;
+        case 24:
+            attrs.underline = false;
+            break;
+        case 27:
+            attrs.inverse = false;
+            break;
+        case 38:
+        case 48: {
+            bool foreground = (param == 38);
+            if (i + 1 < parameters.size()) {
+                int mode = parameters[++i];
+                if (mode == 5) {
+                    if (i + 1 < parameters.size()) {
+                        int colorIndex = parameters[++i];
+                        auto expand = [](int idx) -> SDL_Color {
+                            if (idx < 16) {
+                                const SDL_Color palette[16] = {
+                                    {0x00, 0x00, 0x00, 0xff}, {0xaa, 0x00, 0x00, 0xff}, {0x00, 0xaa, 0x00, 0xff}, {0xaa, 0x55, 0x00, 0xff},
+                                    {0x00, 0x00, 0xaa, 0xff}, {0xaa, 0x00, 0xaa, 0xff}, {0x00, 0xaa, 0xaa, 0xff}, {0xaa, 0xaa, 0xaa, 0xff},
+                                    {0x55, 0x55, 0x55, 0xff}, {0xff, 0x55, 0x55, 0xff}, {0x55, 0xff, 0x55, 0xff}, {0xff, 0xff, 0x55, 0xff},
+                                    {0x55, 0x55, 0xff, 0xff}, {0xff, 0x55, 0xff, 0xff}, {0x55, 0xff, 0xff, 0xff}, {0xff, 0xff, 0xff, 0xff},
+                                };
+                                return palette[idx];
+                            }
+                            if (idx >= 16 && idx <= 231) {
+                                int base = idx - 16;
+                                int r = (base / 36) % 6;
+                                int g = (base / 6) % 6;
+                                int b = base % 6;
+                                auto scale = [](int component) { return component == 0 ? 0 : component * 40 + 55; };
+                                return SDL_Color{static_cast<uint8_t>(scale(r)), static_cast<uint8_t>(scale(g)), static_cast<uint8_t>(scale(b)), 0xff};
+                            }
+                            int level = (idx - 232) * 10 + 8;
+                            level = std::clamp(level, 0, 255);
+                            return SDL_Color{static_cast<uint8_t>(level), static_cast<uint8_t>(level), static_cast<uint8_t>(level), 0xff};
+                        };
+                        SDL_Color color = expand(colorIndex);
+                        if (foreground) {
+                            attrs.foreground = color;
+                        } else {
+                            attrs.background = color;
+                        }
+                    }
+                } else if (mode == 2) {
+                    if (i + 3 < parameters.size()) {
+                        uint8_t r = static_cast<uint8_t>(std::clamp(parameters[++i], 0, 255));
+                        uint8_t g = static_cast<uint8_t>(std::clamp(parameters[++i], 0, 255));
+                        uint8_t b = static_cast<uint8_t>(std::clamp(parameters[++i], 0, 255));
+                        SDL_Color color{r, g, b, 0xff};
+                        if (foreground) {
+                            attrs.foreground = color;
+                        } else {
+                            attrs.background = color;
+                        }
+                    }
+                }
+            }
+            break;
+        }
+        default: {
+            bool handled = false;
+            if ((param >= 30 && param <= 37) || (param >= 90 && param <= 97)) {
+                applyColor(param, true);
+                handled = true;
+            } else if ((param >= 40 && param <= 47) || (param >= 100 && param <= 107)) {
+                applyColor(param, false);
+                handled = true;
+            }
+            if (!handled) {
+                // Unhandled parameter - ignore gracefully
+            }
+            break;
+        }
+        }
+    }
+
+    m_screen.setAttributes(attrs);
+}
+
+void AnsiParser::Utf8Decoder::push(uint8_t byte, const std::function<void(char32_t)>& emit) {
+    if (m_expected == 0) {
+        if (byte < 0x80) {
+            emit(byte);
+        } else if ((byte & 0xe0) == 0xc0) {
+            m_codepoint = byte & 0x1f;
+            m_expected = 1;
+        } else if ((byte & 0xf0) == 0xe0) {
+            m_codepoint = byte & 0x0f;
+            m_expected = 2;
+        } else if ((byte & 0xf8) == 0xf0) {
+            m_codepoint = byte & 0x07;
+            m_expected = 3;
+        } else {
+            reset();
+        }
+    } else {
+        if ((byte & 0xc0) == 0x80) {
+            m_codepoint = (m_codepoint << 6) | (byte & 0x3f);
+            --m_expected;
+            if (m_expected == 0) {
+                emit(static_cast<char32_t>(m_codepoint));
+                m_codepoint = 0;
+            }
+        } else {
+            reset();
+        }
+    }
+}
+
+void AnsiParser::Utf8Decoder::reset() {
+    m_codepoint = 0;
+    m_expected = 0;
+}
+

--- a/src/crt_effect.cpp
+++ b/src/crt_effect.cpp
@@ -1,0 +1,150 @@
+#include "CRTEffect.h"
+
+#include <SDL2/SDL.h>
+
+#include <algorithm>
+#include <array>
+#include <vector>
+
+CRTEffect::CRTEffect()
+    : m_rng(std::random_device{}()) {}
+
+CRTEffect::~CRTEffect() {
+    if (m_noiseTexture) {
+        SDL_DestroyTexture(m_noiseTexture);
+    }
+    if (m_vignetteTexture) {
+        SDL_DestroyTexture(m_vignetteTexture);
+    }
+}
+
+void CRTEffect::ensureResources(SDL_Renderer* renderer, int width, int height) {
+    int existingWidth = 0;
+    int existingHeight = 0;
+
+    if (m_noiseTexture) {
+        SDL_QueryTexture(m_noiseTexture, nullptr, nullptr, &existingWidth, &existingHeight);
+        if (existingWidth != width || existingHeight != height) {
+            SDL_DestroyTexture(m_noiseTexture);
+            m_noiseTexture = nullptr;
+        }
+    }
+
+    if (!m_noiseTexture) {
+        m_noiseTexture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, width, height);
+        SDL_SetTextureBlendMode(m_noiseTexture, SDL_BLENDMODE_BLEND);
+    }
+
+    existingWidth = existingHeight = 0;
+    if (m_vignetteTexture) {
+        SDL_QueryTexture(m_vignetteTexture, nullptr, nullptr, &existingWidth, &existingHeight);
+        if (existingWidth != width || existingHeight != height) {
+            SDL_DestroyTexture(m_vignetteTexture);
+            m_vignetteTexture = nullptr;
+        }
+    }
+
+    if (!m_vignetteTexture) {
+        m_vignetteTexture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, width, height);
+        SDL_SetTextureBlendMode(m_vignetteTexture, SDL_BLENDMODE_MOD);
+        drawVignette(renderer, width, height);
+    }
+}
+
+void CRTEffect::apply(SDL_Renderer* renderer, SDL_Texture* source) {
+    int width = 0;
+    int height = 0;
+    SDL_QueryTexture(source, nullptr, nullptr, &width, &height);
+    ensureResources(renderer, width, height);
+
+    SDL_SetRenderTarget(renderer, nullptr);
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+    SDL_RenderClear(renderer);
+
+    SDL_SetTextureColorMod(source, 255, 255, 255);
+    SDL_SetTextureAlphaMod(source, 255);
+    SDL_RenderCopy(renderer, source, nullptr, nullptr);
+
+    drawScanlines(renderer, width, height);
+    updateNoise(width, height);
+
+    if (m_noiseTexture) {
+        SDL_SetTextureAlphaMod(m_noiseTexture, 32);
+        SDL_RenderCopy(renderer, m_noiseTexture, nullptr, nullptr);
+    }
+
+    if (m_vignetteTexture) {
+        SDL_RenderCopy(renderer, m_vignetteTexture, nullptr, nullptr);
+    }
+}
+
+void CRTEffect::updateNoise(int width, int height) {
+    if (!m_noiseTexture) {
+        return;
+    }
+
+    void* pixels = nullptr;
+    int pitch = 0;
+    if (SDL_LockTexture(m_noiseTexture, nullptr, &pixels, &pitch) != 0) {
+        return;
+    }
+
+    std::uniform_int_distribution<int> dist(0, 30);
+    SDL_PixelFormat* format = SDL_AllocFormat(SDL_PIXELFORMAT_RGBA8888);
+    if (!format) {
+        SDL_UnlockTexture(m_noiseTexture);
+        return;
+    }
+    auto* row = static_cast<uint8_t*>(pixels);
+    for (int y = 0; y < height; ++y) {
+        auto* pixel = reinterpret_cast<uint32_t*>(row);
+        for (int x = 0; x < width; ++x) {
+            uint8_t noise = static_cast<uint8_t>(dist(m_rng));
+            pixel[x] = SDL_MapRGBA(format, noise, noise, noise, noise);
+        }
+        row += pitch;
+    }
+
+    SDL_UnlockTexture(m_noiseTexture);
+    SDL_FreeFormat(format);
+}
+
+void CRTEffect::drawVignette(SDL_Renderer* renderer, int width, int height) {
+    if (!m_vignetteTexture) {
+        return;
+    }
+
+    SDL_SetRenderTarget(renderer, m_vignetteTexture);
+    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDL_RenderClear(renderer);
+
+    SDL_Rect rect{0, 0, width, height};
+    SDL_SetRenderDrawColor(renderer, 30, 30, 30, 0);
+    SDL_RenderFillRect(renderer, &rect);
+
+    const int steps = 64;
+    for (int i = 0; i < steps; ++i) {
+        float t = static_cast<float>(i) / static_cast<float>(steps);
+        uint8_t alpha = static_cast<uint8_t>(std::clamp(255 * t * t, 0.0f, 255.0f));
+        SDL_SetRenderDrawColor(renderer, 0, 0, 0, alpha);
+        SDL_Rect vignetteRect{
+            static_cast<int>(t * 0.5f * width),
+            static_cast<int>(t * 0.5f * height),
+            static_cast<int>(width - t * width),
+            static_cast<int>(height - t * height)};
+        SDL_RenderDrawRect(renderer, &vignetteRect);
+    }
+
+    SDL_SetRenderTarget(renderer, nullptr);
+}
+
+void CRTEffect::drawScanlines(SDL_Renderer* renderer, int width, int height) {
+    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 60);
+    for (int y = 0; y < height; y += 2) {
+        SDL_RenderDrawLine(renderer, 0, y, width - 1, y);
+    }
+}
+

--- a/src/font_atlas.cpp
+++ b/src/font_atlas.cpp
@@ -1,0 +1,165 @@
+#include "FontAtlas.h"
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace {
+TTF_Font* duplicateFontWithStyle(const std::string& path, int pixelSize, uint8_t style) {
+    TTF_Font* font = TTF_OpenFont(path.c_str(), pixelSize);
+    if (!font) {
+        throw std::runtime_error(std::string("Failed to load font: ") + TTF_GetError());
+    }
+
+    int sdlStyle = TTF_STYLE_NORMAL;
+    if (style & FontAtlas::Bold) {
+        sdlStyle |= TTF_STYLE_BOLD;
+    }
+    if (style & FontAtlas::Italic) {
+        sdlStyle |= TTF_STYLE_ITALIC;
+    }
+    TTF_SetFontStyle(font, sdlStyle);
+    TTF_SetFontHinting(font, TTF_HINTING_LIGHT);
+    return font;
+}
+}
+
+FontAtlas::FontAtlas(SDL_Renderer* renderer, int pixelSize)
+    : m_renderer(renderer), m_pixelSize(pixelSize) {
+    if (!renderer) {
+        throw std::runtime_error("Renderer must not be null");
+    }
+
+    m_fontPath = resolveFontPath();
+    if (m_fontPath.empty()) {
+        throw std::runtime_error("Unable to locate a suitable monospace font. Set CRT_FONT_PATH to override.");
+    }
+
+    // Warm up regular font to compute metrics
+    auto* font = loadFont(Style::Regular);
+    int minx = 0;
+    int maxx = 0;
+    int miny = 0;
+    int maxy = 0;
+    int advance = 0;
+    if (TTF_GlyphMetrics32(font, U'M', &minx, &maxx, &miny, &maxy, &advance) != 0) {
+        throw std::runtime_error(std::string("Failed to query glyph metrics: ") + TTF_GetError());
+    }
+    m_cellWidth = advance;
+    m_cellHeight = TTF_FontHeight(font);
+    m_ascent = TTF_FontAscent(font);
+    m_descent = -TTF_FontDescent(font);
+}
+
+FontAtlas::~FontAtlas() {
+    for (auto& entry : m_glyphCache) {
+        if (entry.second.texture) {
+            SDL_DestroyTexture(entry.second.texture);
+        }
+    }
+
+    for (auto& entry : m_fonts) {
+        if (entry.second) {
+            TTF_CloseFont(entry.second);
+        }
+    }
+}
+
+const GlyphTexture& FontAtlas::glyph(char32_t codepoint, uint8_t style) {
+    auto key = std::make_tuple(codepoint, style);
+    auto it = m_glyphCache.find(key);
+    if (it != m_glyphCache.end()) {
+        return it->second;
+    }
+
+    GlyphTexture glyphInfo;
+    TTF_Font* font = loadFont(style);
+    int minx = 0;
+    int maxx = 0;
+    int miny = 0;
+    int maxy = 0;
+    int advance = 0;
+    if (TTF_GlyphMetrics32(font, codepoint, &minx, &maxx, &miny, &maxy, &advance) != 0) {
+        if (codepoint != U'?') {
+            return glyph(U'?', style);
+        }
+        throw std::runtime_error(std::string("Failed to query glyph metrics: ") + TTF_GetError());
+    }
+
+    glyphInfo.advance = advance;
+    glyphInfo.bearingX = minx;
+    glyphInfo.bearingY = maxy;
+
+    if (!createGlyphTexture(font, codepoint, glyphInfo)) {
+        if (codepoint != U'?') {
+            return glyph(U'?', style);
+        }
+        throw std::runtime_error(std::string("Failed to render glyph: ") + TTF_GetError());
+    }
+
+    auto [insertedIt, inserted] = m_glyphCache.emplace(key, std::move(glyphInfo));
+    return insertedIt->second;
+}
+
+std::string FontAtlas::resolveFontPath() const {
+    if (const char* overridePath = std::getenv("CRT_FONT_PATH")) {
+        if (std::filesystem::exists(overridePath)) {
+            return std::string(overridePath);
+        }
+    }
+
+    const std::vector<std::string> candidates = {
+        "assets/fonts/JetBrainsMono-Regular.ttf",
+        "/usr/share/fonts/truetype/jetbrains-mono/JetBrainsMono-Regular.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
+        "/usr/share/fonts/truetype/ubuntu/UbuntuMono-R.ttf",
+        "/usr/share/fonts/truetype/freefont/FreeMono.ttf"
+    };
+
+    for (const auto& path : candidates) {
+        if (std::filesystem::exists(path)) {
+            return path;
+        }
+    }
+
+    return {};
+}
+
+TTF_Font* FontAtlas::loadFont(uint8_t styleFlags) {
+    auto it = m_fonts.find(styleFlags);
+    if (it != m_fonts.end()) {
+        return it->second;
+    }
+
+    TTF_Font* font = duplicateFontWithStyle(m_fontPath, m_pixelSize, styleFlags);
+    m_fonts.emplace(styleFlags, font);
+    return font;
+}
+
+SDL_Texture* FontAtlas::createGlyphTexture(TTF_Font* font, char32_t codepoint, GlyphTexture& glyphInfo) {
+    SDL_Color white{255, 255, 255, 255};
+    SDL_Surface* surface = TTF_RenderGlyph32_Blended(font, codepoint, white);
+    if (!surface) {
+        return nullptr;
+    }
+
+    glyphInfo.width = surface->w;
+    glyphInfo.height = surface->h;
+
+    SDL_Texture* texture = SDL_CreateTextureFromSurface(m_renderer, surface);
+    SDL_FreeSurface(surface);
+    if (!texture) {
+        return nullptr;
+    }
+
+    SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
+    glyphInfo.texture = texture;
+    return texture;
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,110 @@
+#include "Terminal.h"
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
+
+#include <exception>
+#include <iostream>
+#include <memory>
+
+namespace {
+constexpr int kInitialWidth = 1920;
+constexpr int kInitialHeight = 1080;
+}
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_TIMER) != 0) {
+        std::cerr << "SDL_Init failed: " << SDL_GetError() << "\n";
+        return 1;
+    }
+
+    if (TTF_Init() != 0) {
+        std::cerr << "TTF_Init failed: " << TTF_GetError() << "\n";
+        SDL_Quit();
+        return 1;
+    }
+
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
+
+    SDL_Window* window = SDL_CreateWindow(
+        "Cool Retro Terminal Clone",
+        SDL_WINDOWPOS_CENTERED,
+        SDL_WINDOWPOS_CENTERED,
+        kInitialWidth,
+        kInitialHeight,
+        SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+
+    if (!window) {
+        std::cerr << "SDL_CreateWindow failed: " << SDL_GetError() << "\n";
+        TTF_Quit();
+        SDL_Quit();
+        return 1;
+    }
+
+    SDL_Renderer* renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+    if (!renderer) {
+        std::cerr << "SDL_CreateRenderer failed: " << SDL_GetError() << "\n";
+        SDL_DestroyWindow(window);
+        TTF_Quit();
+        SDL_Quit();
+        return 1;
+    }
+
+    try {
+        Terminal terminal(renderer, kInitialWidth, kInitialHeight);
+        SDL_StartTextInput();
+
+        bool running = true;
+        SDL_Event event;
+        while (running) {
+            while (SDL_PollEvent(&event)) {
+                switch (event.type) {
+                case SDL_QUIT:
+                    running = false;
+                    break;
+                case SDL_WINDOWEVENT:
+                    if (event.window.event == SDL_WINDOWEVENT_RESIZED) {
+                        terminal.handleWindowSize(event.window.data1, event.window.data2);
+                    }
+                    break;
+                case SDL_TEXTINPUT:
+                    terminal.handleTextInput(event.text.text);
+                    break;
+                case SDL_KEYDOWN:
+                    terminal.handleKeyPress(event.key.keysym, event.key.repeat != 0);
+                    break;
+                default:
+                    break;
+                }
+            }
+
+            terminal.update();
+            terminal.render();
+
+            if (!terminal.isChildAlive()) {
+                running = false;
+            }
+
+            SDL_Delay(16);
+        }
+
+        SDL_StopTextInput();
+    } catch (const std::exception& ex) {
+        std::cerr << "Fatal error: " << ex.what() << "\n";
+        SDL_DestroyRenderer(renderer);
+        SDL_DestroyWindow(window);
+        TTF_Quit();
+        SDL_Quit();
+        return 1;
+    }
+
+    SDL_DestroyRenderer(renderer);
+    SDL_DestroyWindow(window);
+    TTF_Quit();
+    SDL_Quit();
+    return 0;
+}
+

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -1,0 +1,735 @@
+#include "Terminal.h"
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstddef>
+#include <cstdlib>
+#include <string_view>
+#include <cerrno>
+#include <csignal>
+#include <cstring>
+#include <stdexcept>
+#include <system_error>
+
+#include <fcntl.h>
+#include <pty.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <unistd.h>
+
+namespace {
+constexpr int kDefaultFontPixels = 20;
+constexpr uint32_t kCursorBlinkInterval = 530;
+
+int clampInt(int value, int minValue, int maxValue) {
+    return std::max(minValue, std::min(value, maxValue));
+}
+
+TerminalCell makeEmptyCell(const TerminalAttributes& defaults) {
+    TerminalCell cell;
+    cell.codepoint = U' ';
+    cell.foreground = defaults.foreground;
+    cell.background = defaults.background;
+    cell.bold = defaults.bold;
+    cell.italic = defaults.italic;
+    cell.underline = defaults.underline;
+    return cell;
+}
+}
+
+Terminal::Terminal(SDL_Renderer* renderer, int width, int height)
+    : m_renderer(renderer)
+    , m_fontAtlas(renderer, kDefaultFontPixels)
+    , m_crtEffect()
+    , m_parser(*this) {
+    if (!renderer) {
+        throw std::runtime_error("Renderer is null");
+    }
+
+    m_defaultAttributes = TerminalAttributes{};
+    m_currentAttributes = m_defaultAttributes;
+    m_savedAttributes = m_defaultAttributes;
+
+    m_renderTarget = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, width, height);
+    if (!m_renderTarget) {
+        throw std::runtime_error(std::string("Failed to create render target: ") + SDL_GetError());
+    }
+
+    SDL_SetTextureBlendMode(m_renderTarget, SDL_BLENDMODE_BLEND);
+
+    allocateGrid(width, height);
+    initializePty();
+    applyWinsize();
+}
+
+Terminal::~Terminal() {
+    shutdownPty();
+    if (m_renderTarget) {
+        SDL_DestroyTexture(m_renderTarget);
+    }
+}
+
+void Terminal::initializePty() {
+    int master = -1;
+    int slave = -1;
+    if (openpty(&master, &slave, nullptr, nullptr, nullptr) == -1) {
+        throw std::system_error(errno, std::generic_category(), "openpty failed");
+    }
+
+    m_masterFd = master;
+
+    m_childPid = fork();
+    if (m_childPid == -1) {
+        throw std::system_error(errno, std::generic_category(), "fork failed");
+    }
+
+    if (m_childPid == 0) {
+        // Child
+        ::close(master);
+
+        if (setsid() == -1) {
+            _exit(1);
+        }
+
+        if (ioctl(slave, TIOCSCTTY, 0) == -1) {
+            _exit(1);
+        }
+
+        dup2(slave, STDIN_FILENO);
+        dup2(slave, STDOUT_FILENO);
+        dup2(slave, STDERR_FILENO);
+        if (slave > STDERR_FILENO) {
+            ::close(slave);
+        }
+
+        struct termios term;
+        if (tcgetattr(STDIN_FILENO, &term) == 0) {
+            cfmakeraw(&term);
+            term.c_lflag |= ECHO | ICANON;
+            tcsetattr(STDIN_FILENO, TCSANOW, &term);
+        }
+
+        ::setenv("TERM", "xterm-256color", 1);
+        const char* shell = std::getenv("SHELL");
+        if (!shell) {
+            shell = "/bin/bash";
+        }
+        execl(shell, shell, "-l", nullptr);
+        _exit(127);
+    }
+
+    ::close(slave);
+
+    int flags = fcntl(master, F_GETFL, 0);
+    if (flags != -1) {
+        fcntl(master, F_SETFL, flags | O_NONBLOCK);
+    }
+}
+
+void Terminal::shutdownPty() {
+    if (m_masterFd != -1) {
+        ::close(m_masterFd);
+        m_masterFd = -1;
+    }
+
+    if (m_childPid > 0) {
+        int status = 0;
+        if (waitpid(m_childPid, &status, WNOHANG) == 0) {
+            kill(m_childPid, SIGHUP);
+            waitpid(m_childPid, &status, 0);
+        }
+        m_childPid = -1;
+    }
+}
+
+void Terminal::allocateGrid(int width, int height) {
+    m_width = width;
+    m_height = height;
+
+    int newColumns = std::max(2, width / std::max(1, m_fontAtlas.cellWidth()));
+    int newRows = std::max(2, height / std::max(1, m_fontAtlas.cellHeight()));
+
+    std::vector<TerminalCell> newCells(newColumns * newRows, makeEmptyCell(m_defaultAttributes));
+
+    int copyColumns = std::min(m_columns, newColumns);
+    int copyRows = std::min(m_rows, newRows);
+    for (int row = 0; row < copyRows; ++row) {
+        for (int col = 0; col < copyColumns; ++col) {
+            newCells[row * newColumns + col] = m_cells[row * m_columns + col];
+        }
+    }
+
+    m_cells.swap(newCells);
+    m_columns = newColumns;
+    m_rows = newRows;
+
+    m_cursor.row = clampInt(m_cursor.row, 0, m_rows - 1);
+    m_cursor.column = clampInt(m_cursor.column, 0, m_columns - 1);
+    m_needsFullRedraw = true;
+}
+
+void Terminal::applyWinsize() {
+    if (m_masterFd == -1) {
+        return;
+    }
+
+    struct winsize ws {
+        static_cast<unsigned short>(m_rows),
+        static_cast<unsigned short>(m_columns),
+        static_cast<unsigned short>(m_height),
+        static_cast<unsigned short>(m_width)
+    };
+    ioctl(m_masterFd, TIOCSWINSZ, &ws);
+}
+
+void Terminal::handleWindowSize(int width, int height) {
+    if (width == m_width && height == m_height) {
+        return;
+    }
+
+    if (m_renderTarget) {
+        SDL_DestroyTexture(m_renderTarget);
+    }
+
+    m_renderTarget = SDL_CreateTexture(m_renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, width, height);
+    if (!m_renderTarget) {
+        throw std::runtime_error(std::string("Failed to resize render target: ") + SDL_GetError());
+    }
+
+    SDL_SetTextureBlendMode(m_renderTarget, SDL_BLENDMODE_BLEND);
+
+    allocateGrid(width, height);
+    applyWinsize();
+}
+
+void Terminal::update() {
+    updateCursorBlink();
+    flushPendingInput();
+
+    if (m_masterFd == -1) {
+        return;
+    }
+
+    char buffer[4096];
+    while (true) {
+        ssize_t bytes = ::read(m_masterFd, buffer, sizeof(buffer));
+        if (bytes > 0) {
+            m_parser.process(std::string_view(buffer, static_cast<size_t>(bytes)));
+            m_needsFullRedraw = true;
+        } else if (bytes == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            break;
+        } else if (bytes == -1 && errno == EINTR) {
+            continue;
+        } else if (bytes == 0) {
+            // EOF
+            shutdownPty();
+            break;
+        } else {
+            break;
+        }
+    }
+
+    if (m_childPid > 0) {
+        int status = 0;
+        if (waitpid(m_childPid, &status, WNOHANG) == m_childPid) {
+            m_childPid = -1;
+        }
+    }
+}
+
+void Terminal::render() {
+    if (!m_renderTarget) {
+        return;
+    }
+
+    SDL_SetRenderTarget(m_renderer, m_renderTarget);
+    SDL_SetRenderDrawColor(m_renderer, m_defaultAttributes.background.r, m_defaultAttributes.background.g, m_defaultAttributes.background.b, 255);
+    SDL_RenderClear(m_renderer);
+
+    drawCells();
+    drawCursor();
+
+    SDL_SetRenderTarget(m_renderer, nullptr);
+    m_crtEffect.apply(m_renderer, m_renderTarget);
+    SDL_RenderPresent(m_renderer);
+
+    m_needsFullRedraw = false;
+}
+
+void Terminal::updateCursorBlink() {
+    uint32_t ticks = SDL_GetTicks();
+    if (ticks - m_lastBlinkTicks >= kCursorBlinkInterval) {
+        m_cursorBlinkState = !m_cursorBlinkState;
+        m_lastBlinkTicks = ticks;
+    }
+}
+
+void Terminal::drawCells() {
+    const int cellWidth = m_fontAtlas.cellWidth();
+    const int cellHeight = m_fontAtlas.cellHeight();
+
+    for (int row = 0; row < m_rows; ++row) {
+        for (int col = 0; col < m_columns; ++col) {
+            const auto& cell = m_cells[row * m_columns + col];
+            drawCell(row, col, cell);
+        }
+    }
+}
+
+void Terminal::drawCell(int row, int column, const TerminalCell& cell) {
+    const int cellWidth = m_fontAtlas.cellWidth();
+    const int cellHeight = m_fontAtlas.cellHeight();
+
+    SDL_Rect rect{column * cellWidth, row * cellHeight, cellWidth, cellHeight};
+    SDL_SetRenderDrawColor(m_renderer, cell.background.r, cell.background.g, cell.background.b, 255);
+    SDL_RenderFillRect(m_renderer, &rect);
+
+    if (cell.codepoint == U' ') {
+        return;
+    }
+
+    uint8_t style = FontAtlas::Style::Regular;
+    if (cell.bold) {
+        style |= FontAtlas::Style::Bold;
+    }
+    if (cell.italic) {
+        style |= FontAtlas::Style::Italic;
+    }
+
+    const auto& glyph = m_fontAtlas.glyph(cell.codepoint, style);
+    if (glyph.width == 0 || glyph.height == 0) {
+        return;
+    }
+    int baseline = m_fontAtlas.ascent();
+    SDL_Rect dstRect{
+        rect.x + glyph.bearingX,
+        rect.y + baseline - glyph.bearingY,
+        glyph.width,
+        glyph.height};
+    if (dstRect.x < rect.x - cellWidth) {
+        dstRect.x = rect.x - cellWidth;
+    }
+    if (dstRect.x + dstRect.w > rect.x + cellWidth) {
+        dstRect.x = rect.x + cellWidth - dstRect.w;
+    }
+    if (dstRect.y < rect.y - cellHeight) {
+        dstRect.y = rect.y - cellHeight;
+    }
+    if (dstRect.y + dstRect.h > rect.y + cellHeight) {
+        dstRect.y = rect.y + cellHeight - dstRect.h;
+    }
+    SDL_SetTextureColorMod(glyph.texture, cell.foreground.r, cell.foreground.g, cell.foreground.b);
+    SDL_SetTextureAlphaMod(glyph.texture, 255);
+    SDL_RenderCopy(m_renderer, glyph.texture, nullptr, &dstRect);
+
+    if (cell.underline) {
+        SDL_SetRenderDrawColor(m_renderer, cell.foreground.r, cell.foreground.g, cell.foreground.b, 255);
+        SDL_RenderDrawLine(m_renderer, rect.x, rect.y + cellHeight - 2, rect.x + cellWidth, rect.y + cellHeight - 2);
+    }
+}
+
+void Terminal::drawCursor() {
+    if (!m_cursorVisible || !m_cursorBlinkState) {
+        return;
+    }
+
+    const int cellWidth = m_fontAtlas.cellWidth();
+    const int cellHeight = m_fontAtlas.cellHeight();
+    SDL_Rect rect{m_cursor.column * cellWidth, m_cursor.row * cellHeight, cellWidth, cellHeight};
+    SDL_SetRenderDrawBlendMode(m_renderer, SDL_BLENDMODE_ADD);
+    SDL_SetRenderDrawColor(m_renderer, 0, 255, 0, 80);
+    SDL_RenderFillRect(m_renderer, &rect);
+    SDL_SetRenderDrawBlendMode(m_renderer, SDL_BLENDMODE_BLEND);
+}
+
+void Terminal::handleTextInput(const char* text) {
+    if (!text) {
+        return;
+    }
+    writeToPty(text);
+}
+
+void Terminal::handleKeyPress(const SDL_Keysym& keysym, bool repeat) {
+    if (repeat) {
+        return;
+    }
+
+    auto send = [this](std::string_view data) { writeToPty(data); };
+
+    switch (keysym.sym) {
+    case SDLK_RETURN:
+        send("\r");
+        break;
+    case SDLK_BACKSPACE:
+        send("\x7f");
+        break;
+    case SDLK_TAB:
+        send("\t");
+        break;
+    case SDLK_ESCAPE:
+        send("\x1b");
+        break;
+    case SDLK_UP:
+        send("\x1b[A");
+        break;
+    case SDLK_DOWN:
+        send("\x1b[B");
+        break;
+    case SDLK_RIGHT:
+        send("\x1b[C");
+        break;
+    case SDLK_LEFT:
+        send("\x1b[D");
+        break;
+    case SDLK_PAGEUP:
+        send("\x1b[5~");
+        break;
+    case SDLK_PAGEDOWN:
+        send("\x1b[6~");
+        break;
+    case SDLK_HOME:
+        send("\x1b[H");
+        break;
+    case SDLK_END:
+        send("\x1b[F");
+        break;
+    case SDLK_DELETE:
+        send("\x1b[3~");
+        break;
+    default:
+        if (keysym.mod & KMOD_CTRL) {
+            char base = static_cast<char>(std::tolower(static_cast<unsigned char>(keysym.sym)));
+            if (base >= 'a' && base <= 'z') {
+                char control = static_cast<char>(base - 'a' + 1);
+                send(std::string_view(&control, 1));
+            } else if (keysym.sym == SDLK_SPACE) {
+                char nul = 0;
+                send(std::string_view(&nul, 1));
+            }
+        }
+        break;
+    }
+}
+
+bool Terminal::isChildAlive() const {
+    return m_childPid > 0;
+}
+
+void Terminal::writeToPty(std::string_view text) {
+    if (m_masterFd == -1 || text.empty()) {
+        return;
+    }
+
+    size_t offset = 0;
+    while (offset < text.size()) {
+        ssize_t written = ::write(m_masterFd, text.data() + offset, text.size() - offset);
+        if (written > 0) {
+            offset += static_cast<size_t>(written);
+        } else if (written == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            m_pendingInput.append(text.substr(offset));
+            return;
+        } else if (written == -1 && errno == EINTR) {
+            continue;
+        } else {
+            return;
+        }
+    }
+}
+
+void Terminal::flushPendingInput() {
+    if (m_pendingInput.empty() || m_masterFd == -1) {
+        return;
+    }
+
+    std::string pending = std::move(m_pendingInput);
+    size_t offset = 0;
+    while (offset < pending.size()) {
+        ssize_t written = ::write(m_masterFd, pending.data() + offset, pending.size() - offset);
+        if (written > 0) {
+            offset += static_cast<size_t>(written);
+        } else if (written == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            m_pendingInput.assign(pending.begin() + static_cast<std::ptrdiff_t>(offset), pending.end());
+            return;
+        } else if (written == -1 && errno == EINTR) {
+            continue;
+        } else {
+            return;
+        }
+    }
+}
+
+void Terminal::putChar(char32_t codepoint) {
+    if (codepoint == U'\r') {
+        carriageReturn();
+        return;
+    }
+    if (codepoint == U'\n') {
+        lineFeed(true);
+        return;
+    }
+
+    auto& cell = m_cells[m_cursor.row * m_columns + m_cursor.column];
+    cell.codepoint = codepoint;
+    cell.bold = m_currentAttributes.bold;
+    cell.italic = m_currentAttributes.italic;
+    cell.underline = m_currentAttributes.underline;
+    cell.foreground = m_currentAttributes.foreground;
+    cell.background = m_currentAttributes.background;
+    if (m_currentAttributes.inverse) {
+        std::swap(cell.foreground, cell.background);
+    }
+
+    if (m_cursor.column + 1 >= m_columns) {
+        carriageReturn();
+        lineFeed(true);
+    } else {
+        ++m_cursor.column;
+    }
+    m_needsFullRedraw = true;
+}
+
+void Terminal::carriageReturn() {
+    m_cursor.column = 0;
+    m_needsFullRedraw = true;
+}
+
+void Terminal::lineFeed(bool newLine) {
+    if (newLine) {
+        if (m_cursor.row == m_rows - 1) {
+            scrollUp(1);
+        } else {
+            ++m_cursor.row;
+        }
+        m_needsFullRedraw = true;
+    }
+}
+
+void Terminal::backspace() {
+    if (m_cursor.column > 0) {
+        --m_cursor.column;
+        m_needsFullRedraw = true;
+    }
+}
+
+void Terminal::tab() {
+    int next = ((m_cursor.column / 8) + 1) * 8;
+    m_cursor.column = std::min(next, m_columns - 1);
+    m_needsFullRedraw = true;
+}
+
+void Terminal::cursorUp(int amount) {
+    m_cursor.row = clampInt(m_cursor.row - amount, 0, m_rows - 1);
+    m_needsFullRedraw = true;
+}
+
+void Terminal::cursorDown(int amount) {
+    m_cursor.row = clampInt(m_cursor.row + amount, 0, m_rows - 1);
+    m_needsFullRedraw = true;
+}
+
+void Terminal::cursorForward(int amount) {
+    m_cursor.column = clampInt(m_cursor.column + amount, 0, m_columns - 1);
+    m_needsFullRedraw = true;
+}
+
+void Terminal::cursorBackward(int amount) {
+    m_cursor.column = clampInt(m_cursor.column - amount, 0, m_columns - 1);
+    m_needsFullRedraw = true;
+}
+
+void Terminal::cursorNextLine(int amount) {
+    cursorDown(amount);
+    carriageReturn();
+}
+
+void Terminal::cursorPrevLine(int amount) {
+    cursorUp(amount);
+    carriageReturn();
+}
+
+void Terminal::setCursorColumn(int column) {
+    m_cursor.column = clampInt(column, 0, m_columns - 1);
+    m_needsFullRedraw = true;
+}
+
+void Terminal::setCursorPosition(int row, int column) {
+    m_cursor.row = clampInt(row, 0, m_rows - 1);
+    m_cursor.column = clampInt(column, 0, m_columns - 1);
+    m_needsFullRedraw = true;
+}
+
+void Terminal::eraseInDisplay(int mode) {
+    switch (mode) {
+    case 0: // from cursor to end
+        eraseInLine(0);
+        for (int row = m_cursor.row + 1; row < m_rows; ++row) {
+            for (int col = 0; col < m_columns; ++col) {
+                m_cells[row * m_columns + col] = makeEmptyCell(m_defaultAttributes);
+            }
+        }
+        break;
+    case 1: // from start to cursor
+        for (int row = 0; row < m_cursor.row; ++row) {
+            for (int col = 0; col < m_columns; ++col) {
+                m_cells[row * m_columns + col] = makeEmptyCell(m_defaultAttributes);
+            }
+        }
+        for (int col = 0; col <= m_cursor.column; ++col) {
+            m_cells[m_cursor.row * m_columns + col] = makeEmptyCell(m_defaultAttributes);
+        }
+        break;
+    case 2: // entire screen
+    default:
+        std::fill(m_cells.begin(), m_cells.end(), makeEmptyCell(m_defaultAttributes));
+        break;
+    }
+    m_needsFullRedraw = true;
+}
+
+void Terminal::eraseInLine(int mode) {
+    switch (mode) {
+    case 0: // from cursor to end
+        for (int col = m_cursor.column; col < m_columns; ++col) {
+            m_cells[m_cursor.row * m_columns + col] = makeEmptyCell(m_defaultAttributes);
+        }
+        break;
+    case 1: // start to cursor
+        for (int col = 0; col <= m_cursor.column; ++col) {
+            m_cells[m_cursor.row * m_columns + col] = makeEmptyCell(m_defaultAttributes);
+        }
+        break;
+    case 2: // entire line
+    default:
+        for (int col = 0; col < m_columns; ++col) {
+            m_cells[m_cursor.row * m_columns + col] = makeEmptyCell(m_defaultAttributes);
+        }
+        break;
+    }
+    m_needsFullRedraw = true;
+}
+
+void Terminal::insertLines(int amount) {
+    amount = std::clamp(amount, 0, m_rows - m_cursor.row);
+    if (amount == 0) {
+        return;
+    }
+
+    for (int row = m_rows - 1; row >= m_cursor.row + amount; --row) {
+        for (int col = 0; col < m_columns; ++col) {
+            m_cells[row * m_columns + col] = m_cells[(row - amount) * m_columns + col];
+        }
+    }
+
+    for (int row = m_cursor.row; row < m_cursor.row + amount; ++row) {
+        for (int col = 0; col < m_columns; ++col) {
+            m_cells[row * m_columns + col] = makeEmptyCell(m_defaultAttributes);
+        }
+    }
+    m_needsFullRedraw = true;
+}
+
+void Terminal::deleteLines(int amount) {
+    amount = std::clamp(amount, 0, m_rows - m_cursor.row);
+    if (amount == 0) {
+        return;
+    }
+
+    for (int row = m_cursor.row; row < m_rows - amount; ++row) {
+        for (int col = 0; col < m_columns; ++col) {
+            m_cells[row * m_columns + col] = m_cells[(row + amount) * m_columns + col];
+        }
+    }
+
+    for (int row = m_rows - amount; row < m_rows; ++row) {
+        for (int col = 0; col < m_columns; ++col) {
+            m_cells[row * m_columns + col] = makeEmptyCell(m_defaultAttributes);
+        }
+    }
+    m_needsFullRedraw = true;
+}
+
+void Terminal::scrollUp(int amount) {
+    amount = std::clamp(amount, 0, m_rows);
+    if (amount == 0) {
+        return;
+    }
+
+    for (int row = 0; row < m_rows - amount; ++row) {
+        for (int col = 0; col < m_columns; ++col) {
+            m_cells[row * m_columns + col] = m_cells[(row + amount) * m_columns + col];
+        }
+    }
+
+    for (int row = m_rows - amount; row < m_rows; ++row) {
+        for (int col = 0; col < m_columns; ++col) {
+            m_cells[row * m_columns + col] = makeEmptyCell(m_defaultAttributes);
+        }
+    }
+    m_needsFullRedraw = true;
+}
+
+void Terminal::scrollDown(int amount) {
+    amount = std::clamp(amount, 0, m_rows);
+    if (amount == 0) {
+        return;
+    }
+
+    for (int row = m_rows - 1; row >= amount; --row) {
+        for (int col = 0; col < m_columns; ++col) {
+            m_cells[row * m_columns + col] = m_cells[(row - amount) * m_columns + col];
+        }
+    }
+
+    for (int row = 0; row < amount; ++row) {
+        for (int col = 0; col < m_columns; ++col) {
+            m_cells[row * m_columns + col] = makeEmptyCell(m_defaultAttributes);
+        }
+    }
+    m_needsFullRedraw = true;
+}
+
+void Terminal::setAttributes(const TerminalAttributes& attributes) {
+    m_currentAttributes = attributes;
+    m_needsFullRedraw = true;
+}
+
+TerminalAttributes& Terminal::attributes() {
+    return m_currentAttributes;
+}
+
+const TerminalAttributes& Terminal::defaultAttributes() const {
+    return m_defaultAttributes;
+}
+
+void Terminal::reset() {
+    m_currentAttributes = m_defaultAttributes;
+    m_cursor = {};
+    m_savedCursor = {};
+    m_savedAttributes = m_defaultAttributes;
+    std::fill(m_cells.begin(), m_cells.end(), makeEmptyCell(m_defaultAttributes));
+    m_parser.reset();
+    m_needsFullRedraw = true;
+}
+
+void Terminal::saveCursor() {
+    m_savedCursor = m_cursor;
+    m_savedAttributes = m_currentAttributes;
+}
+
+void Terminal::restoreCursor() {
+    m_cursor = m_savedCursor;
+    m_currentAttributes = m_savedAttributes;
+    m_needsFullRedraw = true;
+}
+
+void Terminal::setCursorVisible(bool visible) {
+    m_cursorVisible = visible;
+    m_needsFullRedraw = true;
+}
+


### PR DESCRIPTION
## Summary
- add a CMake-based SDL2/SDL_ttf application scaffold
- implement a PTY-backed terminal emulator with ANSI/VT parsing, font atlas, and CRT visual effects
- document build prerequisites and usage details for the retro terminal clone

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e2b58bcabc83279c79c9d196304da0